### PR TITLE
refa: avoid hard-coded uid in helm chart

### DIFF
--- a/charts/steadybit-extension-azure/Chart.yaml
+++ b/charts/steadybit-extension-azure/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: steadybit-extension-azure
 description: Steadybit azure extension Helm chart for Kubernetes.
-version: 1.1.8
+version: 1.1.9
 appVersion: v1.0.14
 home: https://www.steadybit.com/
 icon: https://steadybit-website-assets.s3.amazonaws.com/logo-symbol-transparent.png

--- a/charts/steadybit-extension-azure/templates/deployment.yaml
+++ b/charts/steadybit-extension-azure/templates/deployment.yaml
@@ -131,15 +131,10 @@ spec:
             httpGet:
               path: /health/readiness
               port: 8081
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         {{- include "extensionlib.deployment.volumes" (list .) | nindent 8 }}
       serviceAccountName: {{ .Values.serviceAccount.name }}

--- a/charts/steadybit-extension-azure/tests/__snapshot__/deployment_test.yaml.snap
+++ b/charts/steadybit-extension-azure/tests/__snapshot__/deployment_test.yaml.snap
@@ -106,10 +106,11 @@ manifest should match snapshot using podAnnotations and Labels:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with TLS:
@@ -222,13 +223,14 @@ manifest should match snapshot with TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /etc/extension/certificates/server-cert
                   name: certificate-server-cert
                   readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes:
             - name: certificate-server-cert
@@ -341,10 +343,11 @@ manifest should match snapshot with azure certificates vars:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with azure secrets vars:
@@ -453,10 +456,11 @@ manifest should match snapshot with azure secrets vars:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with extra env vars:
@@ -572,10 +576,11 @@ manifest should match snapshot with extra env vars:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with extra labels:
@@ -686,10 +691,11 @@ manifest should match snapshot with extra labels:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with mutual TLS:
@@ -804,9 +810,6 @@ manifest should match snapshot with mutual TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts:
                 - mountPath: /etc/extension/certificates/client-cert-a
                   name: certificate-client-cert-a
@@ -814,6 +817,10 @@ manifest should match snapshot with mutual TLS:
                 - mountPath: /etc/extension/certificates/server-cert
                   name: certificate-server-cert
                   readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes:
             - name: certificate-client-cert-a
@@ -936,10 +943,11 @@ manifest should match snapshot with mutual TLS using containerPaths:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with podSecurityContext:
@@ -1048,12 +1056,12 @@ manifest should match snapshot with podSecurityContext:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
           securityContext:
+            runAsNonRoot: true
             runAsUser: 2222
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot with priority class:
@@ -1162,11 +1170,12 @@ manifest should match snapshot with priority class:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
           priorityClassName: my-priority-class
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null
 manifest should match snapshot without TLS:
@@ -1275,9 +1284,10 @@ manifest should match snapshot without TLS:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
-                runAsGroup: 10000
-                runAsNonRoot: true
-                runAsUser: 10000
               volumeMounts: null
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           serviceAccountName: steadybit-extension-azure
           volumes: null

--- a/charts/steadybit-extension-azure/values.yaml
+++ b/charts/steadybit-extension-azure/values.yaml
@@ -99,7 +99,18 @@ affinity: {}
 priorityClassName: null
 
 # podSecurityContext -- SecurityContext to apply to the pod.
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+  runAsNonRoot: true
+
+# containerSecurityContext -- SecurityContext to apply to the container.
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
 
 # extraEnv -- Array with extra environment variables to add to the container
 # e.g:


### PR DESCRIPTION
In order to improve installation on openshift, we need to avoid the hard-coded uid/gid in the helm chart